### PR TITLE
Limit message history fetch to recent messages

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -22,8 +22,10 @@ async def get_msg_history(msg: Message) -> list[Message]:
     # Get the message history
     if isinstance(msg.answer_to, int):
         # If it's an answer, get the last 10 previous messages in the thread
+        # We only fetch the most recent messages (50) since we just need
+        # enough to reconstruct the reply chain without loading the whole topic.
         full_history: list[Message] = await redis().get_topic_messages(
-            msg.topic_id, count=200
+            msg.topic_id, count=50
         )
         msg_history = [msg]
         last_answer_to: int = msg.answer_to


### PR DESCRIPTION
## Summary
- Limit Redis topic history fetch to the latest 50 messages
- Document strategy for fetching minimal message history

## Testing
- `TOGETHER_API_KEY=dummy python - <<'PY'
import asyncio
from onchebot.models import Message
import importlib
import ai
importlib.reload(ai)

class FakeRedis:
    def __init__(self, messages):
        self.messages = messages
    async def get_topic_messages(self, topic_id, count):
        return self.messages[-count:]

messages = [
    Message(
        id=i,
        stickers=[],
        mentions=[],
        content_html="",
        content_without_stickers="",
        content=f"msg {i}",
        username=f"user{i}",
        timestamp=0,
        topic_id=123,
        answer_to=i-1 if i>1 else None,
    )
    for i in range(1, 1001)
]

ai.redis = lambda: FakeRedis(messages)
msg = messages[-1]

history = asyncio.run(ai.get_msg_history(msg))
print(len(history), history[0].id, history[-1].id)
PY`
- `python -m py_compile ai.py`

------
https://chatgpt.com/codex/tasks/task_e_688ebf11b2b483258c797ee41b676d93