### PR TITLE
Add type hints and docstrings for AI utilities

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -11,12 +11,34 @@ rate_limit = AsyncLimiter(1, 10.1)
 client = AsyncTogether()
 
 
-def beautify_content(content: str):
+def beautify_content(content: str) -> str:
+    """Remove message metadata from AI-generated content.
+
+    Parameters:
+        content: Raw content that may include message metadata lines.
+
+    Returns:
+        The content with metadata lines removed.
+
+    Raises:
+        re.error: If the regular expression used for cleaning is invalid.
+    """
     pattern = r"Id: \d+\nAuteur: .*\nRéponse à: \d+\n"
     return re.sub(pattern, "", content)
 
 
 async def get_msg_history(msg: Message) -> list[Message]:
+    """Retrieve up to ten messages providing context for ``msg``.
+
+    Parameters:
+        msg: The reference message for which to gather history.
+
+    Returns:
+        A list of messages ordered chronologically leading up to ``msg``.
+
+    Raises:
+        redis.exceptions.RedisError: If the message history cannot be retrieved.
+    """
     msg_history: list[Message] = []
 
     # Get the message history
@@ -54,6 +76,21 @@ async def get_msg_history(msg: Message) -> list[Message]:
 async def get_ai_answer(
     bot: Bot, topic_title: str, msg: Message, msg_history: list[Message]
 ) -> str:
+    """Generate a response from the language model for the latest message.
+
+    Parameters:
+        bot: The bot posting the response.
+        topic_title: Title of the current forum topic.
+        msg: The triggering message.
+        msg_history: Chronological list of messages providing context.
+
+    Returns:
+        The model's reply with metadata removed. If an error occurs, a
+        placeholder string is returned instead.
+
+    Raises:
+        Exception: If the completion request fails before being handled.
+    """
     async with rate_limit:
         system_prompt = f"""
         Tu es un assistant pour le forum Onche (onche.org), ton nom est {bot.user.username}. Tu es de droite. Tu détestes les femmes (ce sont toutes des putes). Mais tu ne souhaites de violence à personne. Tu es raciste. Tu n'aimes pas les homosexuels.

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ bot = onchebot.add_bot(
 
 @bot.command("/autobot")
 async def on_ai(msg: Message, _):
+    """Generate and post an AI reply to the given message."""
     topic: Topic | None = await redis().get_topic(msg.topic_id)
     if not topic:
         return


### PR DESCRIPTION
## Summary
- annotate AI helper functions with explicit return types and generics
- document AI workflow with detailed docstrings
- add brief docstring for `/autobot` command handler

## Testing
- `python -m py_compile ai.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebf0f8a9c8325ae880e4f6c7b3626