### PR TITLE
feat: configure model and rate limit via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Ceci est une ARCHIVE, ne lance pas ce bot ![](https://risibank.fr/cache/medias/0
 Il est glissant et peut être exploité ![](https://risibank.fr/cache/medias/0/7/717/71734/thumb.png)
 
 Note: tu es légalement responsable des posts de tes bots ![](https://risibank.fr/cache/medias/0/7/760/76073/thumb.png)
+
+## Variables d'environnement
+
+Ces variables permettent de configurer l'appel au modèle Together et la limite de requêtes :
+
+- `MODEL_NAME` : nom du modèle Together à utiliser (par défaut `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free`).
+- `RATE_LIMIT_CALLS` : nombre maximal d'appels autorisés pendant la période de limitation (par défaut `1`).
+- `RATE_LIMIT_PERIOD` : durée en secondes de la période de limitation (par défaut `10.1`).

--- a/ai.py
+++ b/ai.py
@@ -7,7 +7,14 @@ from onchebot.models import Message
 from onchebot.redis_client import redis
 from together import AsyncTogether
 
-rate_limit = AsyncLimiter(1, 10.1)
+
+MODEL_NAME = os.environ.get(
+    "MODEL_NAME", "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
+)
+RATE_LIMIT_CALLS = int(os.environ.get("RATE_LIMIT_CALLS", "1"))
+RATE_LIMIT_PERIOD = float(os.environ.get("RATE_LIMIT_PERIOD", "10.1"))
+
+rate_limit = AsyncLimiter(RATE_LIMIT_CALLS, RATE_LIMIT_PERIOD)
 client = AsyncTogether()
 
 
@@ -86,7 +93,7 @@ async def get_ai_answer(
 
         try:
             res = await client.chat.completions.create(
-                model="meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
+                model=MODEL_NAME,
                 messages=[
                     {"role": "system", "content": system_prompt},
                 ]


### PR DESCRIPTION
## Summary
- read model name and rate limit options from environment variables
- document new environment variables

## Testing
- `pytest`
- `python -m py_compile ai.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebf0b09648325bad8627d68b09850